### PR TITLE
Add --without-perl option

### DIFF
--- a/postgresql@9.6.rb
+++ b/postgresql@9.6.rb
@@ -43,6 +43,7 @@ class PostgresqlAT96 < Formula
       --with-perl
       --with-python
       --with-tcl
+      --without-perl
       XML2_CONFIG=:
     ]
 

--- a/postgresql@9.6.rb
+++ b/postgresql@9.6.rb
@@ -40,7 +40,6 @@ class PostgresqlAT96 < Formula
       --with-openssl
       --with-uuid=e2fs
       --with-pam
-      --with-perl
       --with-python
       --with-tcl
       --without-perl


### PR DESCRIPTION
For **macOS Mojave** we get an error while installing and found this solution [here](https://discourse.brew.sh/t/error-when-brew-install-postgres-on-mojave-beta-3/2540).